### PR TITLE
Better test for the predefined "any" type

### DIFF
--- a/_testdata/9/foo.go
+++ b/_testdata/9/foo.go
@@ -1,1 +1,8 @@
-type nine = int
+type nineA = int
+
+func nineB(x interface{}) interface{} {
+	type any = interface{}
+
+	var y any = x // should not require Go 1.18 (where any is predefined)
+	return y
+}

--- a/expr.go
+++ b/expr.go
@@ -69,8 +69,8 @@ func (p *pkgScanner) exprHelper(expr ast.Expr, isCallFun bool) error {
 
 func (p *pkgScanner) ident(ident *ast.Ident) error {
 	if tv, ok := p.info.Types[ident]; ok && tv.IsType() && ident.Name == "any" {
-		// It's a type named "any," but is it actually the "any" type?
-		if intf, ok := tv.Type.Underlying().(*types.Interface); ok && intf.Empty() {
+		// It's a type named "any," but is it the predefined "any" type?
+		if obj, ok := p.info.Uses[ident]; ok && obj.Pkg() == nil {
 			idResult := posResult{
 				version: 18,
 				pos:     p.fset.Position(ident.Pos()),


### PR DESCRIPTION
This PR checks that the use of `any` as a type name actually refers to the predefined type introduced in Go 1.18 and doesn't simply denote a (user-defined) empty interface.