### PR TITLE
In API lookups, use the exported object ID

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -80,8 +80,12 @@ func (p *pkgScanner) ident(ident *ast.Ident) error {
 			return nil
 		}
 	}
+
 	obj, ok := p.info.Uses[ident]
 	if !ok || obj == nil {
+		return nil
+	}
+	if !obj.Exported() {
 		return nil
 	}
 	pkg := obj.Pkg()
@@ -89,7 +93,8 @@ func (p *pkgScanner) ident(ident *ast.Ident) error {
 		return nil
 	}
 	pkgpath := obj.Pkg().Path()
-	if v := p.s.lookup(pkgpath, ident.Name, ""); v > 0 {
+
+	if v := p.s.lookup(pkgpath, obj.Id(), ""); v > 0 {
 		idResult := posResult{
 			version: v,
 			pos:     p.fset.Position(ident.Pos()),


### PR DESCRIPTION
In API lookups, use the exported object ID, not whatever ID the user has assigned (a use of) it to.