### PR TITLE
Do not scan files in $GOCACHE; do not skip scanning of args to builtins

### DIFF
--- a/_testdata/bug14/go.mod
+++ b/_testdata/bug14/go.mod
@@ -1,0 +1,3 @@
+module bug14
+
+go 1.18

--- a/_testdata/bug14/main.go
+++ b/_testdata/bug14/main.go
@@ -1,0 +1,32 @@
+// I am indebted to https://github.com/alexdyukov for this code
+// and the attendant bug report.
+// See https://github.com/bobg/mingo/issues/14
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+)
+
+func main() {
+	fmt.Println(len(customReadAll(io.NopCloser(&bytes.Buffer{}))))
+}
+
+func customReadAll(reader io.Reader) []byte {
+	buf := make([]byte, 100)
+	retVal := []byte{}
+	for {
+		n, err := reader.Read(buf)
+
+		retVal = append(retVal, buf...)
+		buf = buf[:0]
+
+		if n < 100 || err != nil {
+			return retVal
+		}
+	}
+
+	return nil
+}

--- a/expr.go
+++ b/expr.go
@@ -386,6 +386,10 @@ func (p *pkgScanner) callExpr(expr *ast.CallExpr) error {
 		return nil
 	}
 
+	return p.callArgs(expr)
+}
+
+func (p *pkgScanner) callArgs(expr *ast.CallExpr) error {
 	for _, arg := range expr.Args {
 		if err := p.expr(arg); err != nil {
 			return err
@@ -394,7 +398,6 @@ func (p *pkgScanner) callExpr(expr *ast.CallExpr) error {
 			return nil
 		}
 	}
-
 	return nil
 }
 
@@ -465,7 +468,8 @@ func (p *pkgScanner) builtinCall(expr *ast.CallExpr) error {
 		}
 		p.greater(result)
 	}
-	return nil
+
+	return p.callArgs(expr)
 }
 
 func getID(expr ast.Expr) *ast.Ident {

--- a/history_test.go
+++ b/history_test.go
@@ -31,6 +31,11 @@ func TestHistory(t *testing.T) {
 		pkgpath: "crypto/elliptic",
 		ident:   "Curve",
 		want:    0,
+	}, {
+		// https://github.com/bobg/mingo/issues/14
+		pkgpath: "io",
+		ident:   "NopCloser",
+		want:    16,
 	}}
 
 	for _, tc := range cases {

--- a/regression_test.go
+++ b/regression_test.go
@@ -1,0 +1,15 @@
+package mingo
+
+import "testing"
+
+// https://github.com/bobg/mingo/issues/14
+func TestBug14(t *testing.T) {
+	var s Scanner
+	res, err := s.ScanDir("_testdata/bug14")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v := res.Version(); v != 16 {
+		t.Errorf("got %d, want 16", v)
+	}
+}

--- a/scan.go
+++ b/scan.go
@@ -226,15 +226,21 @@ func (s *Scanner) isMax() bool {
 	return s.Result.Version() >= s.h.max
 }
 
-var goCache = os.Getenv("GOCACHE")
-
 func isCacheFile(filename string) (bool, error) {
-	if goCache == "" {
-		return false, nil
+	cacheDir := os.Getenv("GOCACHE")
+	if cacheDir == "" {
+		var err error
+		cacheDir, err = os.UserCacheDir()
+		if err != nil {
+			return false, errors.Wrap(err, "getting user cache directory")
+		}
+		if cacheDir == "" {
+			return false, nil
+		}
 	}
-	rel, err := filepath.Rel(goCache, filename)
+	rel, err := filepath.Rel(cacheDir, filename)
 	if err != nil {
-		return false, errors.Wrapf(err, "computing relative path from %s to %s", goCache, filename)
+		return false, errors.Wrapf(err, "computing relative path from %s to %s", cacheDir, filename)
 	}
 	return !strings.HasPrefix(rel, "../"), nil
 }


### PR DESCRIPTION
This PR causes mingo to skip scanning files that appear under `$GOCACHE`, and adds scanning of arguments to builtin calls like `len` (which was missing). Fixes #14. Thank you to @alexdyukov for the assist!