### PR TITLE
Don't skip the type in a composite literal

### DIFF
--- a/_testdata/bug26/bug26.go
+++ b/_testdata/bug26/bug26.go
@@ -1,0 +1,14 @@
+// Thank you to Matthew R Kasun for reporting this issue!
+// See https://github.com/bobg/mingo/issues/26
+
+package main
+
+import (
+	"fmt"
+	"text/template/parse"
+)
+
+func main() {
+	foo := parse.BreakNode{}
+	fmt.Print(foo)
+}

--- a/_testdata/bug26/go.mod
+++ b/_testdata/bug26/go.mod
@@ -1,0 +1,3 @@
+module bug26
+
+go 1.18

--- a/expr.go
+++ b/expr.go
@@ -180,6 +180,9 @@ func (p *pkgScanner) funcBody(body *ast.BlockStmt) (bool, error) {
 }
 
 func (p *pkgScanner) compositeLit(lit *ast.CompositeLit) (bool, error) {
+	if isMax, err := p.expr(lit.Type); err != nil || isMax {
+		return isMax, err
+	}
 	for _, elt := range lit.Elts {
 		if isMax, err := p.expr(elt); err != nil || isMax {
 			return isMax, err

--- a/history_test.go
+++ b/history_test.go
@@ -36,6 +36,11 @@ func TestHistory(t *testing.T) {
 		pkgpath: "io",
 		ident:   "NopCloser",
 		want:    16,
+	}, {
+		// https://github.com/bobg/mingo/issues/26
+		pkgpath: "text/template/parse",
+		ident:   "BreakNode",
+		want:    18,
 	}}
 
 	for _, tc := range cases {

--- a/regression_test.go
+++ b/regression_test.go
@@ -13,3 +13,14 @@ func TestBug14(t *testing.T) {
 		t.Errorf("got %d, want 16", v)
 	}
 }
+
+func TestBug26(t *testing.T) {
+	var s Scanner
+	res, err := s.ScanDir("_testdata/bug26")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v := res.Version(); v != 18 {
+		t.Errorf("got %d, want 18", v)
+	}
+}


### PR DESCRIPTION
Fixes #26. Many thanks to @mattkasun for the bug report!