### PR TITLE
fix: cache path checks across Windows volumes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,13 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+
+    runs-on: ${{ matrix.os }}
 
     permissions:
       issues: write
@@ -29,13 +35,14 @@ jobs:
         run: go test -coverprofile=cover.out ./...
 
       - name: Send coverage
+        if: runner.os == 'Linux'
         uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: cover.out
         continue-on-error: true
 
       - name: Modver
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ runner.os == 'Linux' && github.event_name == 'pull_request' }}
         uses: bobg/modver@v2.14.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/scan.go
+++ b/scan.go
@@ -263,9 +263,16 @@ func isCacheFile(filename string) (bool, error) {
 			return false, nil
 		}
 	}
-	rel, err := filepath.Rel(cacheDir, filename)
+	return isWithinDir(cacheDir, filename), nil
+}
+
+// isWithinDir reports whether filename lies inside dir, using a purely lexical check
+// (no filesystem I/O, no symlink resolution).
+// Paths that cannot be made relative - e.g. on different Windows volumes - are treated as outside dir.
+func isWithinDir(dir, filename string) bool {
+	rel, err := filepath.Rel(dir, filename)
 	if err != nil {
-		return false, errors.Wrapf(err, "computing relative path from %s to %s", cacheDir, filename)
+		return false
 	}
-	return !strings.HasPrefix(rel, "../"), nil
+	return filepath.IsLocal(rel)
 }

--- a/scan.go
+++ b/scan.go
@@ -266,9 +266,9 @@ func isCacheFile(filename string) (bool, error) {
 	return isWithinDir(cacheDir, filename), nil
 }
 
-// isWithinDir reports whether filename lies inside dir, using a purely lexical check
-// (no filesystem I/O, no symlink resolution).
-// Paths that cannot be made relative - e.g. on different Windows volumes - are treated as outside dir.
+// isWithinDir reports whether filename is dir or lies inside it.
+// It performs a purely lexical check without filesystem I/O or symlink resolution.
+// Paths that cannot be made relative, such as paths on different Windows volumes, are treated as outside dir.
 func isWithinDir(dir, filename string) bool {
 	rel, err := filepath.Rel(dir, filename)
 	if err != nil {

--- a/scan.go
+++ b/scan.go
@@ -263,16 +263,21 @@ func isCacheFile(filename string) (bool, error) {
 			return false, nil
 		}
 	}
-	return isWithinDir(cacheDir, filename), nil
+	return isWithinDir(cacheDir, filename)
 }
 
-// isWithinDir reports whether filename is dir or lies inside it.
-// It performs a purely lexical check without filesystem I/O or symlink resolution.
-// Paths that cannot be made relative, such as paths on different Windows volumes, are treated as outside dir.
-func isWithinDir(dir, filename string) bool {
+// isWithinDir reports whether filename is lexically within dir.
+// It does not access the filesystem or resolve symlinks.
+// Paths on different volumes are considered outside dir.
+func isWithinDir(dir, filename string) (bool, error) {
+	if !strings.EqualFold(filepath.VolumeName(dir), filepath.VolumeName(filename)) {
+		return false, nil
+	}
+
 	rel, err := filepath.Rel(dir, filename)
 	if err != nil {
-		return false
+		return false, errors.Wrapf(err, "computing relative path from %s to %s", dir, filename)
 	}
-	return filepath.IsLocal(rel)
+
+	return filepath.IsLocal(rel), nil
 }

--- a/scan_test.go
+++ b/scan_test.go
@@ -1,6 +1,7 @@
 package mingo
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/bobg/errors"
@@ -64,4 +65,32 @@ func TestScanErrors(t *testing.T) {
 			t.Fatalf("got nil, want error")
 		}
 	})
+}
+
+func TestIsWithinDir(t *testing.T) {
+	base := t.TempDir()
+	parent := filepath.Dir(base)
+
+	cases := []struct {
+		name     string
+		dir      string
+		filename string
+		want     bool
+	}{
+		{"self", base, base, true},
+		{"child", base, filepath.Join(base, "child.go"), true},
+		{"nested child", base, filepath.Join(base, "subdir", "child.go"), true},
+		{"parent", base, parent, false},
+		{"outside via parent", base, filepath.Join(parent, "outside.go"), false},
+		{"sibling", filepath.Join(base, "cache"), filepath.Join(base, "sibling", "x.go"), false},
+		{"common prefix", filepath.Join(base, "cache"), filepath.Join(base, "cache-other", "x.go"), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isWithinDir(tc.dir, tc.filename); got != tc.want {
+				t.Errorf("isWithinDir(%q, %q) = %v, want %v", tc.dir, tc.filename, got, tc.want)
+			}
+		})
+	}
 }

--- a/scan_test.go
+++ b/scan_test.go
@@ -88,7 +88,11 @@ func TestIsWithinDir(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := isWithinDir(tc.dir, tc.filename); got != tc.want {
+			got, err := isWithinDir(tc.dir, tc.filename)
+			if err != nil {
+				t.Fatalf("isWithinDir(%q, %q): unexpected error: %v", tc.dir, tc.filename, err)
+			}
+			if got != tc.want {
 				t.Errorf("isWithinDir(%q, %q) = %v, want %v", tc.dir, tc.filename, got, tc.want)
 			}
 		})

--- a/scan_windows_test.go
+++ b/scan_windows_test.go
@@ -5,28 +5,40 @@ package mingo
 import "testing"
 
 func TestIsWithinDirWindowsDifferentVolumes(t *testing.T) {
-	if isWithinDir(
+	got, err := isWithinDir(
 		`C:\Users\runneradmin\AppData\Local`,
 		`D:\a\project\project.go`,
-	) {
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got {
 		t.Fatal("path on another volume reported as contained")
 	}
 }
 
 func TestIsWithinDirWindowsSameVolumeOutside(t *testing.T) {
-	if isWithinDir(
+	got, err := isWithinDir(
 		`C:\Users\runneradmin\AppData\Local`,
 		`C:\git\project\project.go`,
-	) {
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got {
 		t.Fatal("outside path reported as contained")
 	}
 }
 
 func TestIsWithinDirWindowsChild(t *testing.T) {
-	if !isWithinDir(
+	got, err := isWithinDir(
 		`C:\Users\runneradmin\AppData\Local`,
 		`C:\Users\runneradmin\AppData\Local\go-build\x.go`,
-	) {
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got {
 		t.Fatal("child path not reported as contained")
 	}
 }

--- a/scan_windows_test.go
+++ b/scan_windows_test.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package mingo
+
+import "testing"
+
+func TestIsWithinDirWindowsDifferentVolumes(t *testing.T) {
+	if isWithinDir(
+		`C:\Users\runneradmin\AppData\Local`,
+		`D:\a\project\project.go`,
+	) {
+		t.Fatal("path on another volume reported as contained")
+	}
+}
+
+func TestIsWithinDirWindowsSameVolumeOutside(t *testing.T) {
+	if isWithinDir(
+		`C:\Users\runneradmin\AppData\Local`,
+		`C:\git\project\project.go`,
+	) {
+		t.Fatal("outside path reported as contained")
+	}
+}
+
+func TestIsWithinDirWindowsChild(t *testing.T) {
+	if !isWithinDir(
+		`C:\Users\runneradmin\AppData\Local`,
+		`C:\Users\runneradmin\AppData\Local\go-build\x.go`,
+	) {
+		t.Fatal("child path not reported as contained")
+	}
+}


### PR DESCRIPTION
`filepath.Rel` returns an error on Windows when the cache directory and scanned source file are located on different volumes.
That condition means the source file is not inside cache and should not abort scan.

Changes:

* treats paths on different volumes as outside cache
* uses platform-aware lexical containment checks
* fixes same-volume Windows paths using backslash separators
* adds Windows-specific regression tests
* runs test suite on Windows in CI

Fixes #17